### PR TITLE
Fix initial robot state

### DIFF
--- a/src/server/src/Server.cpp
+++ b/src/server/src/Server.cpp
@@ -82,10 +82,8 @@ bool Server::configure(ResourceFinder &rf)
         return false;
     }
 
-    /* Move in a safe position and idle the robot. */
-    enable_position_control();
-    drdMoveToPos(0.0, 0.0, 0.0, false);
-    state_ = State::PositionControl;
+    /* Start and idle the robot. */
+    state_ = State::Idle;
 
     std::cout << "Server running..." << std::endl;
 


### PR DESCRIPTION
Fix the initial behavior of the robot to prevent it from moving and collide with objects placed in front of it. After this change, the robot stays at initial position after startup and goes in idle state.