### PR TITLE
Update the cmake minimum required version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 #
 #===============================================================================
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.18)
 
 project(yarp-omega-3 LANGUAGES CXX VERSION 3.10.1)
 


### PR DESCRIPTION
According to [cmake documentation](https://cmake.org/cmake/help/latest/release/3.18.html), the subcommand `ARCHIVE_EXTRACT` used here

 https://github.com/robotology-playground/yarp-omega3/blob/5d18b5ca6ee90a562bab250fbf4ac185afb4a9a0/src/server/CMakeLists.txt#L42 

is available from 3.18 version.